### PR TITLE
Fix alt text for GIF

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -47,7 +47,7 @@ const About = () => {
             <p>Let's make magic🧙🏾‍♂️✨</p>
           </HashLink>
         </div>
-        <img src={require("./green.gif")} alt="" />
+        <img src={require("./green.gif")} alt="Decorative green animation" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add accessible alt description for `green.gif`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c593c8944832dae448ea79468b173