### PR TITLE
Fix CSS keyframes syntax

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,7 @@ body {
     opacity: 1;
     transform: scale(1);
   }
+}
 
 @keyframes float {
   0% {


### PR DESCRIPTION
## Summary
- close `@keyframes zoomIn` block in `index.css`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b767f57c832d94eb14b30d94c15e