### PR TITLE
Remove unused App wrapper styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,10 @@ import Footer from "./components/Footer";
 import HomePage from "./components/HomePage";
 // import NavigationBar from "./components/NavBar";
 import Projects from "./components/Projects";
-import classes from "./components/HomePage.module.css";
 
 function App() {
   return (
-    <div className={classes.body}>
+    <div>
       {/* <NavigationBar /> */}
       <HomePage />
       <About />


### PR DESCRIPTION
## Summary
- delete import of `HomePage.module.css`
- remove `className={classes.body}` wrapper div

## Testing
- `npm test -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b08db638832db9fe870bf3599b0c